### PR TITLE
Print whole fractions without denominator

### DIFF
--- a/BigRational.js
+++ b/BigRational.js
@@ -145,7 +145,10 @@ var bigRat = (function () {
             },
             toString: function () {
                 var o = obj.reduce();
-                return o.num.toString() + "/" + o.denom.toString();
+                if (o.denom.equals(1))
+                    return o.num.toString();
+                else
+                    return o.num.toString() + "/" + o.denom.toString();
             },
             valueOf: function() {
                 return obj.num / obj.denom;


### PR DESCRIPTION
When denominator is equal to 1, toString'ed bigRat's look silly ("198/1"). Do not print slash and denominator in these cases.