### PR TITLE
Declare `bigInt` in strict mode.

### DIFF
--- a/BigRational.js
+++ b/BigRational.js
@@ -1,5 +1,6 @@
 ;var bigRat = (function () {
     "use strict";
+    var bigInt;
     if (typeof require === "function") {
         bigInt = require("big-integer");
     }


### PR DESCRIPTION
Currently fails with `ReferenceError: bigInt is not defined`.