### PR TITLE
Fix parsing of negative decimal numbers

### DIFF
--- a/BigRational.js
+++ b/BigRational.js
@@ -214,11 +214,13 @@
                 return significand.over(exponent);
             }
         }
-        parts = n.split(".");
+        parts = n.trim().split(".");
         if(parts.length > 2) {
             throw new Error("Invalid input: too many '.' tokens");
         }
         if(parts.length > 1) {
+            var isNegative = parts[0][0] === '-';
+            if (isNegative) parts[0] = parts[0].slice(1);
             var intPart = new BigRational(bigInt(parts[0]), bigInt[1]);
             var length = parts[1].length;
             while(parts[1][0] === "0") {
@@ -227,8 +229,8 @@
             var exp = "1" + Array(length + 1).join("0");
             var decPart = reduce(bigInt(parts[1]), bigInt(exp));
             intPart = intPart.add(decPart);
-	    if (parts[0][0] === '-') intPart = intPart.negate();
-    	    return intPart;
+            if (isNegative) intPart = intPart.negate();
+            return intPart;
         }
         return new BigRational(bigInt(n), bigInt[1]);
     }

--- a/BigRational.test.js
+++ b/BigRational.test.js
@@ -51,7 +51,10 @@ var testResults = (function () {
         "9/10 toDecimal = '0.9'": bigRat(9, 10).toDecimal() === "0.9", // Issue #2
         "-1 - -0.9 = -0.1": bigRat(-1).subtract(-0.9).valueOf() === -0.1, // Issue #9
         "9.999701656077919E307 = 9.999701656077919e307": bigRat("9.999701656077919E307").equals("9.999701656077919e307"), // Issue #11
-        "55/-75 toDecimal = -55/75 toDecimal": bigRat("55", "-75").toDecimal() === bigRat("-55", "75").toDecimal() // Issue #10
+        "55/-75 toDecimal = -55/75 toDecimal": bigRat("55", "-75").toDecimal() === bigRat("-55", "75").toDecimal(), // Issue #10
+        "valueOf -1.5 = -1.5": bigRat(-1.5).valueOf() === -1.5,
+        "valueOf \" -1.5\" = -1.5": bigRat(" -1.5").valueOf() === -1.5,
+        "valueOf \"-1.5 \" = -1.5": bigRat("-1.5 ").valueOf() === -1.5
     };
     for(var i in asserts) {
         var result = i + ": ";


### PR DESCRIPTION
Before this commit, `bigRat` would output the following values:

```js
+bigRat(-1.5); // 0.5
+bigRat(" -1.5"); // 0.5
+bigRat("-1.5 "); // 0.95
```
