### PR TITLE
Updated big-integer dependency  to new version that fixes division bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "arithmetic"
   ],
   "dependencies" : {
-	"big-integer" :  "1.5.x"
-  }, 
+	"big-integer" :  "^1.6.19"
+  },
   "license": "WTFPL",
   "engines": {
     "node": ">=0.6"


### PR DESCRIPTION
Okay, sending pull request with the big-integer dependency updated. I've tried the test case that gave an error before, and it looks like it works now.